### PR TITLE
Add option to set the Karaf logfile

### DIFF
--- a/chef/cookbooks/opendaylight/attributes/default.rb
+++ b/chef/cookbooks/opendaylight/attributes/default.rb
@@ -17,3 +17,4 @@
 # limitations under the License.
 #
 
+default[:opendaylight][:logfile] = "/dev/null"

--- a/chef/cookbooks/opendaylight/recipes/default.rb
+++ b/chef/cookbooks/opendaylight/recipes/default.rb
@@ -26,7 +26,7 @@ if node[:platform_family] == "suse"
     code <<-EOF
       case "$(pidof karaf | wc -w)" in
       0) echo "Restarting OpenDayLight Karaf"
-         /opt/distribution-karaf-0.4.0-Beryllium/bin/start
+         KARAF_REDIRECT=#{node[:opendaylight][:logfile]} /opt/distribution-karaf-0.4.0-Beryllium/bin/start
          ;;
       1) echo "Karaf already running. Nothing to do"
          ;;

--- a/chef/data_bags/crowbar/template-opendaylight.json
+++ b/chef/data_bags/crowbar/template-opendaylight.json
@@ -3,7 +3,7 @@
   "description": "Software defined network",
   "attributes": {
     "opendaylight": {
-      
+      "logfile" : "/dev/null"
     }
   },
   "deployment": {

--- a/chef/data_bags/crowbar/template-opendaylight.schema
+++ b/chef/data_bags/crowbar/template-opendaylight.schema
@@ -12,7 +12,7 @@
           "type": "map",
           "required": true,
           "mapping": {
-            
+            "logfile": { "type": "str", "required": true }
           }
         }
       }

--- a/crowbar_framework/app/views/barclamp/opendaylight/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/opendaylight/_edit_attributes.html.haml
@@ -3,3 +3,4 @@
     = header show_raw_deployment?, true
 
   .panel-body
+    = string_field :logfile

--- a/crowbar_framework/config/locales/opendaylight/en.yml
+++ b/crowbar_framework/config/locales/opendaylight/en.yml
@@ -20,3 +20,4 @@ en:
   barclamp:
     opendaylight:
       edit_attributes:
+        logfile: 'Karaf logfile'


### PR DESCRIPTION
Add barclamp attribute to set the logfile for the Karaf container.
This also fixes the JSON schema validation problems when trying to
apply the barclamp since at least one attribute is required by crowbar.

~$ kwalify -f chef/data_bags/crowbar/template-opendaylight.schema
ERROR: [/mapping/attributes/mapping/opendaylight/mapping] required at least one element.

Signed-off-by: Markos Chandras mchandras@suse.de
