### PR TITLE
[WIP] Initial commit - Heat Translator for TOSCA templates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Crowbar: Opendaylight
+# Crowbar: NFV
 
 The code and documentation is distributed under the [Apache 2 license](http://www.apache.org/licenses/LICENSE-2.0.html).
 Contributions back to the source are encouraged.
@@ -6,6 +6,7 @@ Contributions back to the source are encouraged.
 The [Crowbar Framework](https://github.com/crowbar/crowbar) is currently maintained by [SUSE](http://www.suse.com/) as
 an [OpenStack](http://openstack.org) installation framework but is prepared to be a much broader function tool. It was
 originally developed by the [Dell CloudEdge Solutions Team](http://dell.com/openstack).
+This extension (https://github.com/crowbar/crowbar-nfv) allows for deployment of projects and solutions based on the requirements detailed in the OPNFV community (https://opnfv.org) to realize NFV use-cases.
 
 ## Badges
 

--- a/bin/crowbar_tosca
+++ b/bin/crowbar_tosca
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
+@barclamp = "tosca"
+
+main

--- a/chef/cookbooks/crowbar-nfv/README.md
+++ b/chef/cookbooks/crowbar-nfv/README.md
@@ -1,0 +1,23 @@
+Description
+====
+
+This is a cookbook for helping install and configure NFV/SDN projects
+as part of Crowbar.
+
+License and Author
+====
+
+Author:: Madhu Mohan Nelemane <mmnelemane@suse.com>
+Copyright:: 2016 SUSE Linux GmBH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/chef/cookbooks/crowbar-nfv/definitions/default.rb
+++ b/chef/cookbooks/crowbar-nfv/definitions/default.rb
@@ -1,11 +1,11 @@
 #
-# Copyright 2016, SUSE LINUX Products GmbH
+# Copyright 2016, SUSE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,19 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
-
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0

--- a/chef/cookbooks/crowbar-nfv/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-nfv/libraries/helpers.rb
@@ -1,11 +1,11 @@
 #
-# Copyright 2016, SUSE LINUX Products GmbH
+# Copyright 2014, SUSE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +14,21 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
+class Chef
+  class Recipe
+    # Helpers wrapping CrowbarNFVHelper, provided for convenience for
+    # direct calls from recipes.
+  end
+end
 
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+# Helpers wrapping CrowbarNFVHelper, provided for convenience for direct
+# calls from templates.
+class Chef
+  class Resource
+    class Template
+    end
+  end
+end
+
+class CrowbarNFVHelper
+end

--- a/chef/cookbooks/crowbar-nfv/metadata.rb
+++ b/chef/cookbooks/crowbar-nfv/metadata.rb
@@ -1,0 +1,9 @@
+name "crowbar-nfv"
+maintainer "Crowbar Project"
+maintainer_email "crowbar@dell.com"
+license "Apache 2.0"
+description "Help install/configure NFV/SDN projects, deployed by Crowbar"
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
+version "0.1"
+
+depends "crowbar-openstack"

--- a/chef/cookbooks/tosca/attributes/default.rb
+++ b/chef/cookbooks/tosca/attributes/default.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: opendaylight
+# Attributes:: default
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default[:tosca][:verbose] = true
+default[:tosca][:debug] = true

--- a/chef/cookbooks/tosca/metadata.rb
+++ b/chef/cookbooks/tosca/metadata.rb
@@ -1,0 +1,24 @@
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+maintainer "Crowbar Project"
+maintainer_email "crowbar@dell.com"
+license "Apache 2.0"
+description "TOSCA-Template parser and translator to HOT"
+long_description ""
+version "0.0.1"
+
+recipe "tosca", "VNF Template parser for TOSCA-template and translator to HOT"

--- a/chef/cookbooks/tosca/recipes/default.rb
+++ b/chef/cookbooks/tosca/recipes/default.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: opendaylight
+# Recipe:: default
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if node[:platform_family] == "suse"
+  package "python-tosca-parser"
+  package "openstack-heat-translator"
+end
+

--- a/chef/cookbooks/tosca/recipes/role_tosca_parser.rb
+++ b/chef/cookbooks/tosca/recipes/role_tosca_parser.rb
@@ -1,0 +1,17 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "tosca::default"

--- a/chef/cookbooks/tosca/templates/default/jetty.xml.erb
+++ b/chef/cookbooks/tosca/templates/default/jetty.xml.erb
@@ -1,0 +1,107 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//
+DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
+
+<Configure class="org.eclipse.jetty.server.Server">
+
+    <!-- =========================================================== -->
+    <!-- Set connectors -->
+    <!-- =========================================================== -->
+    <!-- One of each type! -->
+    <!-- =========================================================== -->
+
+    <!-- Use this connector for many frequently idle connections and for
+        threadless continuations. -->
+    <Call name="addConnector">
+        <Arg>
+            <New class="org.eclipse.jetty.server.nio.SelectChannelConnector">
+                <Set name="host">
+                    <Property name="jetty.host" />
+                </Set>
+                <Set name="port">
+                    <Property name="jetty.port" default="8181" />
+                </Set>
+                <Set name="maxIdleTime">300000</Set>
+                <Set name="Acceptors">2</Set>
+                <Set name="statsOn">false</Set>
+                <Set name="confidentialPort">8543</Set>
+                <Set name="lowResourcesConnections">20000</Set>
+                <Set name="lowResourcesMaxIdleTime">5000</Set>
+            </New>
+        </Arg>
+    </Call>
+    <Call name="addConnector">
+      <Arg>
+        <New class="org.eclipse.jetty.server.nio.SelectChannelConnector">
+          <Set name="host">
+            <Property name="jetty.host" />
+          </Set>
+          <Set name="port">
+            <Property name="jetty.port" default="<%= @port %>"/>
+          </Set>
+          <Set name="maxIdleTime">300000</Set>
+          <Set name="Acceptors">2</Set>
+          <Set name="statsOn">false</Set>
+          <Set name="confidentialPort">8443</Set>
+          <Set name="lowResourcesConnections">20000</Set>
+          <Set name="lowResourcesMaxIdleTime">5000</Set>
+        </New>
+      </Arg>
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Configure Authentication Realms -->
+    <!-- Realms may be configured for the entire server here, or -->
+    <!-- they can be configured for a specific web app in a context -->
+    <!-- configuration (see $(jetty.home)/contexts/test.xml for an -->
+    <!-- example). -->
+    <!-- =========================================================== -->
+    <Call name="addBean">
+        <Arg>
+            <New class="org.eclipse.jetty.plus.jaas.JAASLoginService">
+                <Set name="name">karaf</Set>
+                <Set name="loginModuleName">karaf</Set>
+                <Set name="roleClassNames">
+                    <Array type="java.lang.String">
+                        <Item>org.apache.karaf.jaas.boot.principal.RolePrincipal
+                        </Item>
+                    </Array>
+                </Set>
+            </New>
+        </Arg>
+    </Call>
+    <Call name="addBean">
+        <Arg>
+            <New class="org.eclipse.jetty.plus.jaas.JAASLoginService">
+                <Set name="name">default</Set>
+                <Set name="loginModuleName">karaf</Set>
+                <Set name="roleClassNames">
+                    <Array type="java.lang.String">
+                        <Item>org.apache.karaf.jaas.boot.principal.RolePrincipal
+                        </Item>
+                    </Array>
+                </Set>
+            </New>
+        </Arg>
+    </Call>
+
+</Configure>
+

--- a/chef/data_bags/crowbar/template-tosca.json
+++ b/chef/data_bags/crowbar/template-tosca.json
@@ -1,0 +1,34 @@
+{
+  "id": "template-tosca",
+  "description": "TOSCA Templates for Virtual Network Functions",
+  "attributes": {
+    "tosca": {
+      "verbose" : true,
+      "debug" : true
+    }
+  },
+  "deployment": {
+    "tosca": {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "schema-revision": 101,
+      "element_states": {
+        "tosca": [ "readying", "ready", "applying" ]
+      },
+      "elements": {},
+      "element_order": [
+        [ "tosca-parser" ]
+      ],
+      "element_run_list_order": {
+        "tosca-parser": 82
+      },
+      "config": {
+        "environment": "tosca-base-config",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": [
+        ]
+      }
+    }
+  }
+}

--- a/chef/data_bags/crowbar/template-tosca.schema
+++ b/chef/data_bags/crowbar/template-tosca.schema
@@ -1,0 +1,94 @@
+{
+  "type": "map",
+  "required": true,
+  "mapping": {
+    "id": { "type": "str", "required": true, "pattern": "/^tosca-|^template-tosca$/" },
+    "description": { "type": "str", "required": true },
+    "attributes": {
+      "type": "map",
+      "required": true,
+      "mapping": {
+        "tosca": {
+          "type": "map",
+          "required": true,
+          "mapping": {
+            "verbose": { "type": "bool", "required": false },
+            "debug": { "type": "bool", "required": false }
+          }
+        }
+      }
+    },
+    "deployment": {
+      "type": "map",
+      "required": true,
+      "mapping": {
+        "tosca": {
+          "type": "map",
+          "required": true,
+          "mapping": {
+            "crowbar-revision": { "type": "int", "required": true },
+            "schema-revision": { "type": "int" },
+            "crowbar-committing": { "type": "bool" },
+            "crowbar-applied": { "type": "bool" },
+            "crowbar-status": { "type": "str" },
+            "crowbar-failed": { "type": "str" },
+            "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
+            "elements": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
+            "element_order": {
+              "type": "seq",
+              "required": true,
+              "sequence": [ {
+                "type": "seq",
+                "sequence": [ { "type": "str" } ]
+              } ]
+            },
+            "element_run_list_order": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                = : {
+                  "type": "int",
+                  "required": true
+                }
+              }
+            },
+            "config": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "environment": { "type": "str", "required": true },
+                "mode": { "type": "str", "required": true },
+                "transitions": { "type": "bool", "required": true },
+                "transition_list": {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/chef/roles/tosca-parser.rb
+++ b/chef/roles/tosca-parser.rb
@@ -1,0 +1,6 @@
+name "tosca-parser"
+description "Tosca Role - Node registered as a TOSCA-template parser"
+run_list("recipe[tosca::role_tosca_parser]")
+default_attributes()
+override_attributes()
+

--- a/crowbar_framework/app/assets/javascripts/barclamps/nfv/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/nfv/application.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2016, SUSE LINUX GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/crowbar_framework/app/assets/javascripts/barclamps/tosca/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/tosca/application.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2016, SUSE LINUX GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/crowbar_framework/app/controllers/nfv_controller.rb
+++ b/crowbar_framework/app/controllers/nfv_controller.rb
@@ -14,18 +14,10 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
+class NfvController < BarclampController
+  protected
 
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+  def initialize_service
+    @service_object = NfvService.new logger
+  end
+end

--- a/crowbar_framework/app/controllers/tosca_controller.rb
+++ b/crowbar_framework/app/controllers/tosca_controller.rb
@@ -1,0 +1,23 @@
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class ToscaController < BarclampController
+  protected
+
+  def initialize_service
+    @service_object = ToscaService.new logger
+  end
+end

--- a/crowbar_framework/app/helpers/barclamp/nfv_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/nfv_helper.rb
@@ -14,18 +14,7 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
-
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+module Barclamp
+  module NfvHelper
+  end
+end

--- a/crowbar_framework/app/helpers/barclamp/tosca_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/tosca_helper.rb
@@ -1,0 +1,20 @@
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Barclamp
+  module ToscaHelper
+  end
+end

--- a/crowbar_framework/app/models/nfv_service.rb
+++ b/crowbar_framework/app/models/nfv_service.rb
@@ -14,18 +14,5 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
-
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+class NfvService < ServiceObject
+end

--- a/crowbar_framework/app/models/tosca_service.rb
+++ b/crowbar_framework/app/models/tosca_service.rb
@@ -1,0 +1,55 @@
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class ToscaService < ServiceObject
+  def initialize(thelogger)
+    super(thelogger)
+    @bc_name = "tosca"
+  end
+
+  class << self
+    def role_constraints
+      {
+        "tosca" => {
+          "unique" => false,
+          "count" => -1,
+          "admin" => false,
+          "exclude_platform" => {
+            "windows" => "/.*/"
+          }
+        }
+      }
+    end
+  end
+
+  def create_proposal
+    @logger.debug("tosca create_proposal: entering")
+    base = super
+
+    nodes = NodeObject.all
+    # Don't include the admin node by default, you never know...
+    nodes.delete_if { |n| n.nil? or n.admin? }
+
+    # Ignore nodes that are being discovered
+    base["deployment"]["tosca"]["elements"] = {
+      "updater" => nodes.select { |x| not ["discovering", "discovered"].include?(x.status) }.map { |x| x.name }
+    }
+
+    @logger.debug("tosca create_proposal: exiting")
+    base
+  end
+
+end

--- a/crowbar_framework/app/views/barclamp/nfv/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nfv/_edit_attributes.html.haml
@@ -1,0 +1,7 @@
+= attributes_for @proposal do
+  .panel-sub
+    = header show_raw_deployment?, true
+
+  .panel-body
+    .alert.alert-info
+      = t(".noconfig")

--- a/crowbar_framework/app/views/barclamp/nfv/_edit_deployment.html.haml
+++ b/crowbar_framework/app/views/barclamp/nfv/_edit_deployment.html.haml
@@ -1,0 +1,7 @@
+= deployment_for @proposal do
+  .panel-sub
+    = header true, show_raw_attributes?
+
+  .panel-body
+    .alert.alert-info
+      = t(".noconfig")

--- a/crowbar_framework/app/views/barclamp/nfv/_index.html.haml
+++ b/crowbar_framework/app/views/barclamp/nfv/_index.html.haml
@@ -1,0 +1,9 @@
+.panel-body
+  %p
+    = t(".instructions")
+
+    - unless t(".hint").empty?
+      %em
+        = t(".hint")
+
+= render :partial => "barclamp/index"

--- a/crowbar_framework/app/views/barclamp/tosca/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/tosca/_edit_attributes.html.haml
@@ -1,0 +1,7 @@
+= attributes_for @proposal do
+  .panel-sub
+    = header show_raw_deployment?, true
+
+  .panel-body
+    = boolean_field :debug
+    = boolean_field :verbose

--- a/crowbar_framework/config/locales/nfv/en.yml
+++ b/crowbar_framework/config/locales/nfv/en.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, SUSE LINUX Products GmbH
+# Copyright 2013-2014, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,18 +14,21 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
-
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+en:
+  nav:
+    barclamps:
+      nfv: 'NFV'
+  barclamp:
+    nfv:
+      edit_attributes:
+        noconfig: 'No Configuration Options'
+      edit_deployment:
+        noconfig: 'No Configuration Options'
+      index:
+        title: 'NFV'
+        barclamp: 'Project'
+        state: 'Status'
+        proposal: 'Proposal'
+        description: 'Notice'
+        instructions: 'Create and apply proposals in order from top to bottom.'
+        hint: ''

--- a/crowbar_framework/config/locales/tosca/en.yml
+++ b/crowbar_framework/config/locales/tosca/en.yml
@@ -1,0 +1,25 @@
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+en:
+  nav:
+    tosca: 'TOSCA Template Parser and Translator'
+  barclamp:
+    tosca:
+      edit_attributes:
+        verbose: true
+        debug: true
+

--- a/nfv.yml
+++ b/nfv.yml
@@ -1,5 +1,6 @@
 #
-# Copyright 2016, SUSE LINUX Products GmbH
+# Copyright 2011-2013, Dell
+# Copyright 2013-2014, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,17 +16,32 @@
 #
 
 barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
+  name: 'nfv'
+  display: 'NFV'
+  description: 'NFV Project has multiple components'
+  version: 1
+  user_managed: false
   member:
     - 'nfv'
+  requires:
+    - '@crowbar'
+    - 'horizon'
+    - 'keystone'
+  os_support:
+    - 'ubuntu-10.10'
+    - 'ubuntu-12.04'
 
 crowbar:
   layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+  order: 210
+  run_order: 210
+  chef_order: 210
+  proposal_schema_version: 3
+
+nav:
+  barclamps:
+    nfv:
+      order: 31
+      route: 'index_barclamp_path'
+      params:
+        controller: 'nfv'

--- a/tosca.yml
+++ b/tosca.yml
@@ -1,0 +1,31 @@
+#
+# Copyright 2016, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp:
+  name: 'tosca'
+  display: 'Tosca Translator Service'
+  description: 'TOSCA Template parser and Heat Translator'
+  version: 0
+  user_managed: true
+  member:
+    - 'nfv'
+
+crowbar:
+  layout: 1
+  order: 82
+  run_order: 82
+  chef_order: 82
+  proposal_schema_version: 0


### PR DESCRIPTION
OASIS specifies a standardized template to specify infrastructure requirements for Virtual Network Functions. The template called TOSCA( Topology and Orchestration Specification for Cloud Applications) is parsed by tosca-parser and the resulting artifacts are passed on to Heat-Translator to generate deployable HOT (Heat Orchestration Templates). This branch adds a barclamp that allows to install and configure TOSCA parser and Heat Translator. 

Note: Since these are not integrated with mkcloud, one needs to manually add the following repo on the controller node to get this barclamp to deploy the required packages.
http://download.suse.de/ibs/home:/mmnelemane:/opnfv/Devel_Cloud_7_Mitaka_SLE_12_SP2/home:mmnelemane:opnfv.repo

Attached is a screenshot for deployment through Crowbar-UI.
![screenshot_20161116_180301](https://cloud.githubusercontent.com/assets/13483069/20357278/930b65f4-ac27-11e6-961b-1094fe16a99f.png)
