### PR TITLE
NFV UI to select barclamps optionally with crowbar-nfv

### DIFF
--- a/.hound.ruby.yml
+++ b/.hound.ruby.yml
@@ -35,3 +35,7 @@ Metrics/ClassLength:
 
 Metrics/ModuleLength:
   Max: 500
+
+# Disabled until Ruby version is updated to 3.0
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development do
   gem "sprockets-standalone", "~> 1.2.1"
   gem "sprockets", "~> 2.11.0"
   gem "rspec", "~> 3.1.0"
+  gem "rake", "< 12.0.0"
 end
 
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Crowbar: Opendaylight
+# Crowbar: NFV
 
 The code and documentation is distributed under the [Apache 2 license](http://www.apache.org/licenses/LICENSE-2.0.html).
 Contributions back to the source are encouraged.
@@ -6,6 +6,7 @@ Contributions back to the source are encouraged.
 The [Crowbar Framework](https://github.com/crowbar/crowbar) is currently maintained by [SUSE](http://www.suse.com/) as
 an [OpenStack](http://openstack.org) installation framework but is prepared to be a much broader function tool. It was
 originally developed by the [Dell CloudEdge Solutions Team](http://dell.com/openstack).
+This extension (https://github.com/crowbar/crowbar-nfv) allows for deployment of projects and solutions based on the requirements detailed in the OPNFV community (https://opnfv.org) to realize NFV use-cases.
 
 ## Badges
 

--- a/chef/cookbooks/crowbar-nfv/README.md
+++ b/chef/cookbooks/crowbar-nfv/README.md
@@ -1,0 +1,23 @@
+Description
+====
+
+This is a cookbook for helping install and configure NFV/SDN projects
+as part of Crowbar.
+
+License and Author
+====
+
+Author:: Madhu Mohan Nelemane <mmnelemane@suse.com>
+Copyright:: 2016 SUSE Linux GmBH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/chef/cookbooks/crowbar-nfv/definitions/default.rb
+++ b/chef/cookbooks/crowbar-nfv/definitions/default.rb
@@ -1,11 +1,10 @@
-#
-# Copyright 2016, SUSE LINUX Products GmbH
+# Copyright 2016, SUSE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,19 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
-
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0

--- a/chef/cookbooks/crowbar-nfv/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-nfv/libraries/helpers.rb
@@ -1,11 +1,10 @@
-#
-# Copyright 2016, SUSE LINUX Products GmbH
+# Copyright 2014, SUSE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +13,21 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
+class Chef
+  class Recipe
+    # Helpers wrapping CrowbarNFVHelper, provided for convenience for
+    # direct calls from recipes.
+  end
+end
 
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+# Helpers wrapping CrowbarNFVHelper, provided for convenience for direct
+# calls from templates.
+class Chef
+  class Resource
+    class Template
+    end
+  end
+end
+
+class CrowbarNFVHelper
+end

--- a/chef/cookbooks/crowbar-nfv/metadata.rb
+++ b/chef/cookbooks/crowbar-nfv/metadata.rb
@@ -1,0 +1,9 @@
+name "crowbar-nfv"
+maintainer "Crowbar Project"
+maintainer_email "crowbar@dell.com"
+license "Apache 2.0"
+description "Help install/configure NFV/SDN projects, deployed by Crowbar"
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
+version "0.1"
+
+depends "crowbar-openstack"

--- a/crowbar_framework/app/assets/javascripts/barclamps/nfv/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/nfv/application.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2016, SUSE LINUX GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/crowbar_framework/app/controllers/nfv_controller.rb
+++ b/crowbar_framework/app/controllers/nfv_controller.rb
@@ -1,4 +1,3 @@
-#
 # Copyright 2016, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,18 +13,10 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
+class NfvController < BarclampController
+  protected
 
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+  def initialize_service
+    @service_object = NfvService.new logger
+  end
+end

--- a/crowbar_framework/app/helpers/barclamp/nfv_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/nfv_helper.rb
@@ -1,4 +1,3 @@
-#
 # Copyright 2016, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,18 +13,7 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
-
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+module Barclamp
+  module NfvHelper
+  end
+end

--- a/crowbar_framework/app/models/nfv_service.rb
+++ b/crowbar_framework/app/models/nfv_service.rb
@@ -1,4 +1,4 @@
-#
+###
 # Copyright 2016, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,18 +14,5 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
-
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+class NfvService < ServiceObject
+end

--- a/crowbar_framework/app/views/barclamp/nfv/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nfv/_edit_attributes.html.haml
@@ -1,0 +1,7 @@
+= attributes_for @proposal do
+  .panel-sub
+    = header show_raw_deployment?, true
+
+  .panel-body
+    .alert.alert-info
+      = t(".noconfig")

--- a/crowbar_framework/app/views/barclamp/nfv/_edit_deployment.html.haml
+++ b/crowbar_framework/app/views/barclamp/nfv/_edit_deployment.html.haml
@@ -1,0 +1,7 @@
+= deployment_for @proposal do
+  .panel-sub
+    = header true, show_raw_attributes?
+
+  .panel-body
+    .alert.alert-info
+      = t(".noconfig")

--- a/crowbar_framework/app/views/barclamp/nfv/_index.html.haml
+++ b/crowbar_framework/app/views/barclamp/nfv/_index.html.haml
@@ -1,0 +1,9 @@
+.panel-body
+  %p
+    = t(".instructions")
+
+    - unless t(".hint").empty?
+      %em
+        = t(".hint")
+
+= render :partial => "barclamp/index"

--- a/crowbar_framework/config/locales/nfv/en.yml
+++ b/crowbar_framework/config/locales/nfv/en.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, SUSE LINUX Products GmbH
+# Copyright 2013-2014, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,18 +14,21 @@
 # limitations under the License.
 #
 
-barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
-  member:
-    - 'nfv'
-
-crowbar:
-  layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+en:
+  nav:
+    barclamps:
+      nfv: 'NFV'
+  barclamp:
+    nfv:
+      edit_attributes:
+        noconfig: 'No Configuration Options'
+      edit_deployment:
+        noconfig: 'No Configuration Options'
+      index:
+        title: 'NFV'
+        barclamp: 'Project'
+        state: 'Status'
+        proposal: 'Proposal'
+        description: 'Notice'
+        instructions: 'Create and apply proposals in order from top to bottom.'
+        hint: ''

--- a/nfv.yml
+++ b/nfv.yml
@@ -1,5 +1,6 @@
 #
-# Copyright 2016, SUSE LINUX Products GmbH
+# Copyright 2011-2013, Dell
+# Copyright 2013-2014, SUSE LINUX Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,17 +16,32 @@
 #
 
 barclamp:
-  name: 'opendaylight'
-  display: 'OpenDaylight'
-  description: 'OpenSource Software defined Networking(SDN) Controller'
-  version: 0
-  user_managed: true
+  name: 'nfv'
+  display: 'NFV'
+  description: 'NFV Project has multiple components'
+  version: 1
+  user_managed: false
   member:
     - 'nfv'
+  requires:
+    - '@crowbar'
+    - 'horizon'
+    - 'keystone'
+  os_support:
+    - 'ubuntu-10.10'
+    - 'ubuntu-12.04'
 
 crowbar:
   layout: 1
-  order: 81
-  run_order: 81
-  chef_order: 81
-  proposal_schema_version: 0
+  order: 210
+  run_order: 210
+  chef_order: 210
+  proposal_schema_version: 3
+
+nav:
+  barclamps:
+    nfv:
+      order: 31
+      route: 'index_barclamp_path'
+      params:
+        controller: 'nfv'


### PR DESCRIPTION
If NFV is expected to include more projects, its easier if it can be provided as an option to deploy after the other openstack components are already deployed. Hence this PR provides a separate item in the drop-down for Barclamps. This will be visible to the user only when he installs crowbar-nfv/ on the Admin node.  The NFV related barclamps can be members of this group and can be selected to be installed one by one similar to the Openstack components. 

This PR also updates the Text for OpenDayLight barclamp to say "OpenSource Software defined Networking(SDN) Controller" since it is an SDN controller and not SDN itself. It may make sense if we plan to integrate other SDN controllers in the group.

The screenshot shows a sample UI: 
![screenshot_20161116_175717](https://cloud.githubusercontent.com/assets/13483069/20357041/c61abd60-ac26-11e6-9348-e7f4e56f33bc.png)

