### PR TITLE
Cleanup in ODL installation

### DIFF
--- a/chef/cookbooks/opendaylight/attributes/default.rb
+++ b/chef/cookbooks/opendaylight/attributes/default.rb
@@ -17,5 +17,5 @@
 # limitations under the License.
 #
 
-default[:opendaylight][:features] = "odl-restconf odl-l2switch-switch odl-dlux-core odl-ovsdb-openstack"
+default[:opendaylight][:features] = "odl-netvirt-openstack"
 default[:opendaylight][:port] = "8070"


### PR DESCRIPTION
  - Installation of odl-netvirt-openstack installs all necessary features
    for basic operations from ODL
  - Re-installation of ODL requires stopping the service and clearing all
    the temporary data created by the previous installation of ODL (Karaf).
    Otherwise inconsistent behavior could be expected with ODL at runtime.