### PR TITLE
Setting ACL mode to transparent instead of default "stateful"

### DIFF
--- a/chef/cookbooks/opendaylight/attributes/default.rb
+++ b/chef/cookbooks/opendaylight/attributes/default.rb
@@ -17,5 +17,5 @@
 # limitations under the License.
 #
 
-default[:opendaylight][:features] = "odl-restconf odl-l2switch-switch odl-dlux-core odl-ovsdb-openstack"
+default[:opendaylight][:features] = "odl-netvirt-openstack"
 default[:opendaylight][:port] = "8070"

--- a/chef/cookbooks/opendaylight/templates/default/netvirt-aclservice-config.xml.erb
+++ b/chef/cookbooks/opendaylight/templates/default/netvirt-aclservice-config.xml.erb
@@ -1,0 +1,3 @@
+<aclservice-config xmlns="urn:opendaylight:netvirt:aclservice-config">
+  <security-group-mode><%= @security_group_mode %></security-group-mode>
+</aclservice-config>


### PR DESCRIPTION
Setting ACL to transparent so that security groups are not made mandatory. The option can be made configurable in future PRs. This PR includes the netvirt-acl-config.xml and sets the default mode to "transparent"